### PR TITLE
Attempt to fix broken link from HDF5 hyperspectral lesson to lesson on raster metadata

### DIFF
--- a/_posts/HYPERSPECTRAL/2015-06-08-Work-With-Hyperspectral-Data-In-R.md
+++ b/_posts/HYPERSPECTRAL/2015-06-08-Work-With-Hyperspectral-Data-In-R.md
@@ -166,7 +166,7 @@ that we will use for both data processing and visualization.
 
 More Information on raster metadata:
 
-* [Metadata to understand when working with raster data](http://neondataskills.org/HDF5/Working-With-Rasters/ "Key Attributes of Raster Data")
+* [Metadata to understand when working with raster data](http://neondataskills.org/R/Image-Raster-Data-In-R/ "Key Attributes of Raster Data")
 
 * [Metadata and important concepts associated with multi-band (multi and hyperspectral) rasters](http://neondataskills.org/HDF5/About-Hyperspectral-Remote-Sensing-Data/ "Key Attributes of Raster Data")
 


### PR DESCRIPTION
Link to tutorial on raster data / metadata was broken. Not sure if the updated link is the intended target.