### PR TITLE
Describe `warning` appropriately in intro raster lesson

### DIFF
--- a/_posts/R/dc-spatial-raster/00-Raster-Structure.Rmd
+++ b/_posts/R/dc-spatial-raster/00-Raster-Structure.Rmd
@@ -474,12 +474,12 @@ hist(DSM_HARV,
 
 ```
 
-Notice that an error message is thrown when `R` creates the histogram. 
+Notice that a warning is shown when `R` creates the histogram. 
 
 `Warning in .hist1(x, maxpixels = maxpixels, main = main, plot = plot, ...): 4%  
 of the raster cells were used. 100000 values used.`
 
-This error is caused by the default maximum pixels value of 100,000 associated 
+This warning is caused by the default maximum pixels value of 100,000 associated 
 with the `hist` function. This maximum value is to ensure processing efficiency
 as our data become larger!
 


### PR DESCRIPTION
The output returned by `hist()` is a warning not an error.